### PR TITLE
Feat: Category 생성, 위치 수정 시 tree node 값 받게 수정

### DIFF
--- a/src/main/java/kdkd/youre/backend/domain/category/presentation/CategoryController.java
+++ b/src/main/java/kdkd/youre/backend/domain/category/presentation/CategoryController.java
@@ -5,7 +5,7 @@ import kdkd.youre.backend.domain.category.presentation.dto.request.CategoryPosit
 import kdkd.youre.backend.domain.category.presentation.dto.request.CategorySaveRequest;
 import kdkd.youre.backend.domain.category.presentation.dto.request.CategoryNameUpdateRequest;
 import kdkd.youre.backend.domain.category.presentation.dto.response.CategoryBookmarkFindAllResponse;
-import kdkd.youre.backend.domain.category.presentation.dto.response.CategoryFindAllResponse;
+import kdkd.youre.backend.domain.category.presentation.dto.response.CategoryTreeResponse;
 import kdkd.youre.backend.domain.category.service.CategoryService;
 import kdkd.youre.backend.domain.common.presentation.dto.response.IdResponse;
 import kdkd.youre.backend.global.security.auth.PrincipalDetails;
@@ -27,10 +27,10 @@ public class CategoryController {
 
     //Category 저장
     @PostMapping("")
-    public ResponseEntity<IdResponse> saveCategory(@RequestBody CategorySaveRequest request,
+    public ResponseEntity<CategoryTreeResponse> saveCategory(@RequestBody CategorySaveRequest request,
                                                    @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        IdResponse response = categoryService.saveCategory(request, principalDetails.getMember());
+        CategoryTreeResponse response = categoryService.saveCategory(request, principalDetails.getMember());
         return ResponseEntity.ok().body(response);
     }
 
@@ -56,12 +56,12 @@ public class CategoryController {
 
     //Category Position 수정
     @PatchMapping("{categoryId}/position")
-    public ResponseEntity<Void> updateCategoryPosition(@PathVariable Long categoryId,
-                                                       @RequestBody CategoryPositionUpdateRequest request,
-                                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
+    public ResponseEntity<CategoryTreeResponse> updateCategoryPosition(@PathVariable Long categoryId,
+                                                                                 @RequestBody CategoryPositionUpdateRequest request,
+                                                                                 @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        categoryService.updateCategoryPosition(categoryId, request, principalDetails.getMember());
-        return ResponseEntity.ok().build();
+        CategoryTreeResponse response = categoryService.updateCategoryPosition(categoryId, request, principalDetails.getMember());
+        return ResponseEntity.ok().body(response);
     }
 
     // Category 삭제
@@ -75,10 +75,10 @@ public class CategoryController {
 
     // Category 전체 목록 조회
     @GetMapping("")
-    public ResponseEntity<List<CategoryFindAllResponse>> findAllCategory(
+    public ResponseEntity<List<CategoryTreeResponse>> findAllCategory(
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        List<CategoryFindAllResponse> response = categoryService.findAllCategory(principalDetails.getMember());
+        List<CategoryTreeResponse> response = categoryService.findAllCategory(principalDetails.getMember());
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/kdkd/youre/backend/domain/category/presentation/dto/response/CategoryTreeResponse.java
+++ b/src/main/java/kdkd/youre/backend/domain/category/presentation/dto/response/CategoryTreeResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class CategoryFindAllResponse {
+public class CategoryTreeResponse {
 
     // https://www.npmjs.com/package/@minoru/react-dnd-treeview 형식 맞춤
     private Long id;            // 카테고리 id
@@ -15,9 +15,9 @@ public class CategoryFindAllResponse {
     private String text;        // 카테고리 이름
     private DataDto data;       // 기타 정보(순서)
 
-    public static CategoryFindAllResponse from(Category category) {
+    public static CategoryTreeResponse from(Category category) {
 
-        return CategoryFindAllResponse.builder()
+        return CategoryTreeResponse.builder()
                 .id(category.getId())
                 .parent(category.getParentId())
                 .droppable(category.getDroppable())

--- a/src/main/java/kdkd/youre/backend/domain/category/service/CategoryService.java
+++ b/src/main/java/kdkd/youre/backend/domain/category/service/CategoryService.java
@@ -7,14 +7,13 @@ import kdkd.youre.backend.domain.category.presentation.dto.request.CategoryPosit
 import kdkd.youre.backend.domain.category.presentation.dto.request.CategorySaveRequest;
 import kdkd.youre.backend.domain.category.presentation.dto.request.CategoryNameUpdateRequest;
 import kdkd.youre.backend.domain.category.presentation.dto.response.CategoryBookmarkFindAllResponse;
-import kdkd.youre.backend.domain.category.presentation.dto.response.CategoryFindAllResponse;
+import kdkd.youre.backend.domain.category.presentation.dto.response.CategoryTreeResponse;
 import kdkd.youre.backend.domain.common.presentation.dto.response.IdResponse;
 import kdkd.youre.backend.domain.member.domain.Member;
 import kdkd.youre.backend.global.exception.CustomException;
 import kdkd.youre.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +29,7 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
-    public IdResponse saveCategory(CategorySaveRequest request, Member member) {
+    public CategoryTreeResponse saveCategory(CategorySaveRequest request, Member member) {
 
         checkDuplicateByName(request.getName(), member);
 
@@ -72,9 +71,7 @@ public class CategoryService {
 
         categoryRepository.save(category);
 
-        return IdResponse.builder()
-                .id(category.getId())
-                .build();
+        return CategoryTreeResponse.from(category);
     }
 
     public void updateCategoryName(Long categoryId, CategoryNameUpdateRequest request, Member member) {
@@ -97,7 +94,7 @@ public class CategoryService {
         category.updateCategoryBookmark(request);
     }
 
-    public void updateCategoryPosition(Long categoryId, CategoryPositionUpdateRequest request, Member member) {
+    public CategoryTreeResponse updateCategoryPosition(Long categoryId, CategoryPositionUpdateRequest request, Member member) {
 
         // TODO: 로직정리 필요
         Category category = categoryRepository.findById(categoryId)
@@ -157,6 +154,7 @@ public class CategoryService {
                 category.updateCategoryPosition(newPosition, depth, parentCategory, fullName);
             }
         }
+        return CategoryTreeResponse.from(category);
     }
 
     public void deleteCategory(Long categoryId, Member member) {
@@ -181,11 +179,11 @@ public class CategoryService {
         }
     }
 
-    public List<CategoryFindAllResponse> findAllCategory(Member member) {
+    public List<CategoryTreeResponse> findAllCategory(Member member) {
 
         List<Category> categories = categoryRepository.findAllByMember(member);
         return categories.stream()
-                .map(CategoryFindAllResponse::from)
+                .map(CategoryTreeResponse::from)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #80 
## ✨ 작업 내용
- Category 위치 수정 시 지정해둔 tree의 노드 형태로 값을 받아 변경된 position(==order), droppable 값을 받을 수 있다.
- Category 생성 시 지정해둔 tree의 노드 형태로 값을 받아 tree에 바로 집어넣을 수 있다.
## 📚 기타
